### PR TITLE
Fix argument type of `set_timing()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ where
         Ok(())
     }
 
-    pub fn set_timing(&mut self, integration_time: Option<Gain>) -> Result<(), Error<I2cError>> {
+    pub fn set_timing(&mut self, integration_time: Option<IntegrationTimes>) -> Result<(), Error<I2cError>> {
         if let Some(integration_time) = integration_time {
             self.i2c.write(0x29, &[chip::COMMAND_BIT | chip::CONTROL, integration_time as u8| self.gain as u8])?;
         } else {


### PR DESCRIPTION
I'm currently using this for a project and spotted a minor issue.
The argument type of `set_timing` should be `IntegrationTimes` instead of `Gain`.

Thank you for creating this library!